### PR TITLE
CommonUtil 내 Redis 적용 및 오류 수정

### DIFF
--- a/docker/deploy/domain/dev/docker-compose.blue.yml
+++ b/docker/deploy/domain/dev/docker-compose.blue.yml
@@ -10,6 +10,7 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=dev
       - SPRING_RABBITMQ_HOST=rabbitmq
+      - SPRING_DATA_REDIS_HOST=redis
       - TZ=Asia/Seoul  # <-- timezone 설정 추가
       # JVM timezone 설정 추가 및 JVM 힙 메모리 설정 추가
       - JAVA_TOOL_OPTIONS=-Duser.timezone=Asia/Seoul  -Xms512m -Xmx1g

--- a/docker/deploy/domain/dev/docker-compose.green.yml
+++ b/docker/deploy/domain/dev/docker-compose.green.yml
@@ -10,6 +10,7 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=dev
       - SPRING_RABBITMQ_HOST=rabbitmq
+      - SPRING_DATA_REDIS_HOST=redis
       - TZ=Asia/Seoul  # <-- timezone 설정 추가
       # JVM timezone 설정 추가 및 JVM 힙 메모리 설정 추가
       - JAVA_TOOL_OPTIONS=-Duser.timezone=Asia/Seoul  -Xms512m -Xmx1g

--- a/mpl-domain/src/main/java/com/codeit/sb02mplteam2/domain/mail/service/SmtpEmailService.java
+++ b/mpl-domain/src/main/java/com/codeit/sb02mplteam2/domain/mail/service/SmtpEmailService.java
@@ -4,7 +4,6 @@ import com.codeit.sb02mplteam2.exception.ErrorCode;
 import com.codeit.sb02mplteam2.exception.MplException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Profile;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
@@ -12,7 +11,6 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Profile("dev")
 public class SmtpEmailService implements EmailService{
 
   private final JavaMailSender javaMailSender;

--- a/mpl-domain/src/main/java/com/codeit/sb02mplteam2/util/CommonUtil.java
+++ b/mpl-domain/src/main/java/com/codeit/sb02mplteam2/util/CommonUtil.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.springframework.cache.Cache;
+import org.springframework.data.redis.cache.RedisCache;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class CommonUtil {
@@ -17,6 +18,8 @@ public final class CommonUtil {
       com.github.benmanes.caffeine.cache.Cache<Long, T> caffeineCache
           = (com.github.benmanes.caffeine.cache.Cache<Long, T>) nativeCache;
       return caffeineCache.getIfPresent(id);
+    } else if (cache instanceof RedisCache redisCache) {
+      return redisCache.get(id, tClass);
     }
     return null;
   }

--- a/mpl-domain/src/main/java/com/codeit/sb02mplteam2/util/CommonUtil.java
+++ b/mpl-domain/src/main/java/com/codeit/sb02mplteam2/util/CommonUtil.java
@@ -18,8 +18,8 @@ public final class CommonUtil {
       com.github.benmanes.caffeine.cache.Cache<Long, T> caffeineCache
           = (com.github.benmanes.caffeine.cache.Cache<Long, T>) nativeCache;
       return caffeineCache.getIfPresent(id);
-    } else if (cache instanceof RedisCache redisCache) {
-      return redisCache.get(id, tClass);
+      Cache.ValueWrapper valueWrapper = redisCache.get(id, tClass);
+      return valueWrapper != null ? (T) valueWrapper.get() : null;
     }
     return null;
   }


### PR DESCRIPTION
# PR 요약

이 Pull Request는 **개발 환경 배포를 위한 환경 설정 개선**과 **Redis 캐싱 유틸리티 기능 강화**를 포함합니다.  
또한 이메일 서비스에서 `@Profile("dev")` 제약을 제거하여 더 넓은 범위에서 사용할 수 있도록 변경했습니다.

---

## ⚙️ 환경 설정 업데이트
- `docker-compose.blue.yml`, `docker-compose.green.yml`에 `SPRING_DATA_REDIS_HOST=redis` 환경 변수를 추가  
- 개발 환경에서 Spring 애플리케이션이 Redis 호스트를 올바르게 인식하도록 보장  
- 참고: [[1]](diffhunk://#diff-89052e2cab43f8b67aadbc4ef04e25277c54f0e4ef0f357f50ff524404a62f86R13) [[2]](diffhunk://#diff-c593900338a59dbdd2ecad397e1b393c22210138f6cf4df2219bb7b92a2fbb35R13)

---

## 🗄 캐싱 유틸리티 개선
- `CommonUtil.java` 수정  
- Redis 캐시에서 값을 가져올 수 있도록 `RedisCache` 인스턴스를 확인하고, `get` 메서드를 사용하도록 개선  
- 참고: [[1]](diffhunk://#diff-1e6fec4d438a1c2193b269ab41890ec843dd989fdbddef74575c92ff2145fd8cR9) [[2]](diffhunk://#diff-1e6fec4d438a1c2193b269ab41890ec843dd989fdbddef74575c92ff2145fd8cR21-R22)

---

## ✉️ 서비스 설정 변경
- `SmtpEmailService` 클래스에서 `@Profile("dev")` 어노테이션 제거  
- 개발 환경뿐만 아니라 **모든 프로파일에서 이메일 서비스 사용 가능**
